### PR TITLE
Fix select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.1.2 - 2017-04-06
+
+* [BUGFIX] Fix cases like `channel.select(:snippet).view_count` where attribute does not belong to any selected part.
+
 ## 0.1.1 - 2017-04-04
 
 * [ENHANCEMENT] Add :defaults to `has_attribute`

--- a/lib/yt/core/version.rb
+++ b/lib/yt/core/version.rb
@@ -3,6 +3,6 @@ module Yt
   module Core
     # @return [String] the SemVer-compatible gem version.
     # @see http://semver.org
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end

--- a/lib/yt/resource.rb
+++ b/lib/yt/resource.rb
@@ -6,7 +6,7 @@ module Yt
     # @option data [String] :id The unique ID of a YouTube resource.
     def initialize(data = {})
       @data = data
-      @selected_data_parts = nil
+      @selected_data_parts = []
     end
 
     # @return [String] the resource’s unique ID.
@@ -65,7 +65,7 @@ module Yt
         fetch resources_path, resource_params(options)
       end
 
-      parts = @selected_data_parts || [required_part]
+      parts = (@selected_data_parts + [required_part]).uniq
       if (resource = resources.select(*parts).first)
         parts.each{|part| @data[part] = resource.data[part]}
         @data[required_part]

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -14,6 +14,7 @@ RSpec.configure do |config|
   $existing_video_id     = 'gknzFj_0vvY'
   $another_video_id      = '9bZkp7q19f0'
   $unknown_video_id      = 'invalid-id-'
+  $untagged_video_id     = 'oO6WawhsxTA'
 
   $existing_playlist_id  = 'PL-LeTutc9GRKD3yBDhnRF_yE8UTaQI5Jf'
   $unknown_playlist_id   = 'invalid-id-'

--- a/spec/video/snippet_spec.rb
+++ b/spec/video/snippet_spec.rb
@@ -20,6 +20,15 @@ describe 'Yt::Video’s snippet methods', :server do
     end
   end
 
+  context 'given an video without tags' do
+    let(:attrs) { {id: $untagged_video_id} }
+
+    specify 'return an empty array as the tags', requests: 1 do
+      expect(video.tags).to eq []
+    end
+  end
+
+
   context 'given an unknown video ID' do
     let(:attrs) { {id: $unknown_video_id} }
 


### PR DESCRIPTION
For instance if `channel = Yt::Channel.new(id: ..).select(:snippet)`
and then I ask for `channel.view_count`, the `:statistics` part should
be added to the request even if it was not specified at the beginning.