### PR TITLE
Expect Yt::HTTPError instead of Yt::NoItemsError to pass test

### DIFF
--- a/spec/playlist_item/snippet_spec.rb
+++ b/spec/playlist_item/snippet_spec.rb
@@ -22,8 +22,8 @@ describe 'Yt::PlaylistItem’s snippet methods', :server do
   context 'given an unknown item ID' do
     let(:attrs) { {id: $unknown_item_id} }
 
-    specify 'raise Yt::NoItemsError' do
-      expect{item.title}.to raise_error Yt::NoItemsError
+    specify 'raise Yt::HTTPError' do
+      expect{item.title}.to raise_error Yt::HTTPError
     end
   end
 end


### PR DESCRIPTION
we need this change because YouTube used to return empty array for the same request -- something like this (example of video)

```
{
 "kind": "youtube#videoListResponse",
 "etag": "\"XI7nbFXulYBIpL0ayR_gDh3eu1k/Rk41fm-2TD0VG1yv0-bkUvcBi9s\"",
 "pageInfo": {
  "totalResults": 0,
  "resultsPerPage": 0
 },
 "items": []
}
```

but now they respond with 500 'Backend Error'.

```
{
 "error": {
  "errors": [
   {
    "domain": "global",
    "reason": "backendError",
    "message": "Backend Error"
   }
  ],
  "code": 500,
  "message": "Backend Error"
 }
}
```