### PR TITLE
the sample key got flagged as a secret

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@ h2: "Installing Yt"
     {% highlight ruby %}
 # run this block before using any method of the gem (replace with your key)
 Yt.configure do |config|
-  config.api_key = 'AIzaSyAkHdn_oBEjZIEBlpMiGZP-3Y05NXtrzqY'
+  config.api_key = 'YOUR_KEY_GOES_RIGHT_HERE'
 end{% endhighlight %}
   </dd>
 </dl>


### PR DESCRIPTION
- clarifies the generated key is not the same as the sample key