### PR TITLE
Remove banner_image_url attribute

### DIFF
--- a/docs/channels.html
+++ b/docs/channels.html
@@ -79,7 +79,6 @@ channel = Yt::Channel.mine
 
   {% include dt.html title="Channel’s branding settings" label="success" auth="any authentication works" %}
   <dd><a class="anchor" id="branding_settings"></a><div class="highlight"><pre>
-{% include doc.html instance="Channel#banner_image_url" %}{% include example.html object='channel' method='banner_image_url' result='"https://yt3.ggpht.com/9dh4rj-k-no"' %}
 {% include doc.html instance="Channel#keywords" %}{% include example.html object='channel' method='keywords' result='["Some", "tag"]' %}
 {% include doc.html instance="Channel#unsubscribed_trailer" %}{% include example.html object='channel' method='unsubscribed_trailer' result='"gknzFj_0vvY"' %}
 {% include doc.html instance="Channel#featured_channels_title" %}{% include example.html object='channel' method='featured_channels_title' result='"Featured channels"' %}

--- a/lib/yt/channel.rb
+++ b/lib/yt/channel.rb
@@ -64,11 +64,6 @@ module Yt
     # @return [<Integer>] the number of videos uploaded to the channel.
     has_attribute :video_count, in: :statistics, type: Integer
 
-    # @!attribute [r] banner_image_url
-    # @return [String] the URL for the banner image shown on the channel page
-    #   on the YouTube website. The image is 1060px by 175px.
-    has_attribute :banner_image_url, in: %i(branding_settings image)
-
     # @!attribute [r] keywords
     # @return [Array<String>] the keywords associated with the channel.
     has_attribute :keywords, in: %i(branding_settings channel) do |keywords|

--- a/spec/channel/branding_settings_spec.rb
+++ b/spec/channel/branding_settings_spec.rb
@@ -7,7 +7,6 @@ describe 'Yt::Channel’s branding settings methods', :server do
     let(:attrs) { {id: $existing_channel_id} }
 
     specify 'return all branding settings data with one HTTP call', requests: 1 do
-      expect(channel.banner_image_url).to be_a String
       expect(channel.keywords).to match_array ['YouTube', 'channel', 'test']
       expect(channel.unsubscribed_trailer).to eq 'gknzFj_0vvY'
       expect(channel.featured_channels_title).to eq 'Public featured channels'

--- a/spec/channel/where_spec.rb
+++ b/spec/channel/where_spec.rb
@@ -48,7 +48,7 @@ describe 'Yt::Channel.where', :server do
       expect(list.map &:title).to be
       expect(list.map &:privacy_status).to be
       expect(list.map &:view_count).to be
-      expect(list.map &:banner_image_url).to be
+      expect(list.map &:keywords).to be
     end
   end
 end


### PR DESCRIPTION
YouTube deprecated `brandingSettings.image` endpoint as of Sep 9, 2020
https://developers.google.com/youtube/v3/revision_history#september-9,-2020